### PR TITLE
feat: oidc adjustments

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -128,7 +128,7 @@ services:
           - ./imports/open-klant:/docker-entrypoint-initdb.d
 
   openklant-2:
-      image: maykinmedia/open-klant:2.6.0
+      image: maykinmedia/open-klant:2.6.1
       build: .
       container_name: openklant-2
       profiles:

--- a/imports/keycloak/realm.json
+++ b/imports/keycloak/realm.json
@@ -2683,7 +2683,7 @@
     "defaultSignatureAlgorithm": "RS256",
     "revokeRefreshToken": false,
     "refreshTokenMaxReuse": 0,
-    "accessTokenLifespan": 60,
+    "accessTokenLifespan": 120,
     "accessTokenLifespanForImplicitFlow": 900,
     "ssoSessionIdleTimeout": 1800,
     "ssoSessionMaxLifespan": 36000,

--- a/imports/openklant-2/database/sql/fill-data-on-startup.sh
+++ b/imports/openklant-2/database/sql/fill-data-on-startup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 echo ">>>>  Waiting until Open Klant has initialized the database <<<<"
+sleep 5
 while true
 do
     initiated=$(psql -U openklant -d openklant -t -A -c "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE table_name = 'accounts_user');")


### PR DESCRIPTION
* up access token lifespan to 2 minutes to reflect a more realistic production scenario and avoid a token refresh loop in the nl-portal-frontend-libraries with oidc-react (https://github.com/nl-portal/nl-portal-frontend-libraries/pull/276)
* add short sleep before import so longer migrations have time to run before sql is injected
* up version of open-klant to 2.6.1