### PR TITLE
feat: add haalcentraal bewoning mock service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -164,8 +164,6 @@ services:
     openklant-2-db:
         image: postgres:15
         container_name: openklant-2-db
-        ports:
-            - "54329:5432"
         profiles:
             - zgw
             - openklant
@@ -349,8 +347,18 @@ services:
             - ASPNETCORE_URLS=http://+:5010
         ports:
             - "5010:5010"
-        networks:
-            - brp-api-network
+
+    haalcentraal-bewoningen:
+        container_name: haalcentraal-bewoningen
+        profiles:
+            - zgw
+            - haalcentraal
+        image: ghcr.io/brp-api/haal-centraal-bewoning-bevragen-mock:2.0.1
+        environment:
+            - ASPNETCORE_ENVIRONMENT=Release
+            - ASPNETCORE_URLS=http://+:5010
+        ports:
+            - "5011:5010"
 
     openproduct:
         image: maykinmedia/open-product:1.3.0
@@ -412,9 +420,6 @@ services:
         profiles:
             - zgw
             - openproduct
-networks:
-    brp-api-network:
-        name: brp-api-network
 
 volumes:
     nl-portal-database-data:


### PR DESCRIPTION
* removed redundant network
* removed port assignment from openklant-db to avoid binding unnecessary ports by default. if a developer needs access to the db, they can add the port mapping locally